### PR TITLE
Fix type declaration problem with imposed let-bindings

### DIFF
--- a/issue-1-again.lisp
+++ b/issue-1-again.lisp
@@ -2,8 +2,13 @@
 (in-package :macroexpand-dammit-test)
 (in-suite :macroexpand-dammit-test)
 
+#-allegro
+(declaim (type integer *declared-integer*))
+#+allegro
+(eval-when (:load-toplevel :execute)
+  (proclaim '(type integer *declared-integer*)))
 
-
+(defvar *declared-integer* 0)
 (defvar *compile-time-counter* 0)
 
 (defmacro count-up ()
@@ -66,3 +71,23 @@
            (compiled-fn (compile nil `(lambda () ,expanded))))
       (is (= 4 (funcall compiled-fn)))
       (is (= 2 *compile-time-counter*)))))
+
+(test issue1-type-declaration
+  ;; Ensure that in the absence of a symbol-macro binding, no dummy binding is
+  ;; imposed that would conflict with the type declaration for a global
+  ;; variable.
+  (is (=
+       5
+       (eval
+        (macroexpand-dammit
+         '(symbol-macrolet ((not-a-special-variable 1))
+           (let ((*declared-integer* 2)
+                 (not-a-special-variable 3))
+             (+ *declared-integer* not-a-special-variable)))))))
+  
+  ;; In ANSI CL it is an error to establish a symbol-macro binding for an
+  ;; existing global variable name, so no let binding for such a variable can
+  ;; ever shadow a symbol-macro anyway.
+  (signals error
+    (macroexpand-dammit
+     '(symbol-macrolet ((*declared-integer* 'foo))))))

--- a/issue-1-again.lisp
+++ b/issue-1-again.lisp
@@ -49,11 +49,12 @@
          (symbol-macrolet ((a 100))
            (let ((b (+ a 2)))
              (+ a b))))
-       (macroexpand-dammit
-        '(let ((a 1))
-          (symbol-macrolet ((a 100))
-            (let ((b (+ a 2)))
-              (+ a b)))))))
+       (eval
+        (macroexpand-dammit
+         '(let ((a 1))
+           (symbol-macrolet ((a 100))
+             (let ((b (+ a 2)))
+               (+ a b))))))))
 
   (let ((*compile-time-counter* 0))
     (let* ((expanded

--- a/macroexpand-dammit.lisp
+++ b/macroexpand-dammit.lisp
@@ -86,9 +86,13 @@
 
 
 (defhandler let (let bindings &rest body)
-  (let ((names (loop for binding in bindings 
-		     collect 
-		     (force-first binding))))
+  (let* ((names (loop for binding in bindings 
+                   collect 
+                     (force-first binding)))
+         (symbol-macrolet-names
+          (loop for name in names
+             when (nth-value 1 (macroexpand-1 name *env*))
+             collect name)))
     `(list*
       ',let
       (list 
@@ -99,8 +103,8 @@
 		   `(list ',(first binding)
 			  ,@(e-list (rest binding))))))
       (with-imposed-bindings
-	(,let ,names
-	  (declare (ignorable ,@names))
+	(,let ,symbol-macrolet-names
+	  (declare (ignorable ,@symbol-macrolet-names))
 	  (m-list ,@body))))))
 
 


### PR DESCRIPTION
This is a fix for the problem I brought up in the comments for issue #1. The handler for `let` imposes dummy bindings in order to clear out any existing symbol-macro bindings in the environment so they won't be triggered by macroexpansions further down the code tree. But this should only be strictly necessary if there is already a symbol-macro binding for the symbol for which we are establishing a let-binding, which is something we can explicitly check. In Common Lisp it is a static error to create a symbol-macro binding for an existing global variable in the first place, so by only imposing dummy bindings where there is an active symbol-macro binding, we can ensure that we never cause a compiler error by inadvertently imposing a nil binding for a global variable that has been `declaim`ed to have some non-nil type.
